### PR TITLE
feat: add a public API for generating a triplet ID

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,4 +13,5 @@ export {
   hostTriplet,
   makeTripletWithFallback,
   type Triplet,
+  tripletId,
 } from "./triplet.js";

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { versions } from "node:process";
 
 import type { LoaderOptions } from "./addon.js";
-import { activeTriplet, Triplet } from "./triplet.js";
+import { activeTriplet, Triplet, tripletId } from "./triplet.js";
 import { isNonEmptyString } from "./utility.js";
 
 /**
@@ -60,9 +60,7 @@ export function prebuiltsDirectoryPath(
  * Bijectively maps a triplet to a directory name.
  */
 export function tripletDirectoryName(triplet: Triplet): string {
-  return [triplet.platform, triplet.arch, triplet.libc]
-    .filter(isNonEmptyString)
-    .join("-");
+  return tripletId(triplet);
 }
 export function versionedAddonFilename(
   name: string,

--- a/src/triplet.ts
+++ b/src/triplet.ts
@@ -91,6 +91,15 @@ export function activeTriplet(): Triplet {
   return makeTripletWithFallback(configuredTriplet(), hostTriplet());
 }
 
+/**
+ * Bijectively maps a triplet to a filesystem-safe string.
+ */
+export function tripletId(triplet: Triplet): string {
+  return [triplet.platform, triplet.arch, triplet.libc]
+    .filter(isNonEmptyString)
+    .join("-");
+}
+
 export function makeTripletWithFallback(
   partialTriplet: Partial<Triplet>,
   fallback: Triplet,


### PR DESCRIPTION
A triplet id can be quite useful for naming CMake presets, therefore repurpose the directory naming scheme as the triplet id scheme.